### PR TITLE
Potential fix for code scanning alert no. 45: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -21,6 +23,9 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/chadkluck/npm-chadkluck-cache-data/security/code-scanning/45](https://github.com/chadkluck/npm-chadkluck-cache-data/security/code-scanning/45)

To fix the issue, we will add a `permissions` block to the workflow. The `build` job only needs `contents: read` to check out the repository and run tests. The `publish-npm` job requires `contents: read` to access the repository and `packages: write` to publish the package to the npm registry. These permissions adhere to the principle of least privilege.

The `permissions` block will be added at the job level for both `build` and `publish-npm` jobs to ensure each job has only the permissions it needs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
